### PR TITLE
Modification d'entête

### DIFF
--- a/calc-litt-01.html
+++ b/calc-litt-01.html
@@ -39,7 +39,7 @@
 <!-- ----------------------------- -->
 
 <h1>Résumé de calcul littéral</h1>
-<h2>Expressions littérales</h2>
+    
 <h3>Signification d'une égalité entre deux expressions littérales (exemple)</h3>
 <p>Pour n'importe quelles valeurs données à $a$ et $b$, l'expression  $10 a+b – a – b$
 donne le même résultat que l'expression 


### PR DESCRIPTION
Suite au mail de JP qui disait qu'ils n'avaient pas été précis sur les contenus des résumés de "Calcul littéral".
Ainsi, la ligne formatée en <h2> avec "Expressions littérales" devrait disparaître.